### PR TITLE
Fill in missing var substitution.

### DIFF
--- a/kubecost-masterpayer-account-permissions.yaml
+++ b/kubecost-masterpayer-account-permissions.yaml
@@ -15,7 +15,7 @@ Resources:
   KubecostRole:
     Type: 'AWS::IAM::Role'
     Properties:
-      RoleName: 'KubecostRole-${KubecostClusterID}'
+      RoleName: !Sub 'KubecostRole-${KubecostClusterID}'
       AssumeRolePolicyDocument:
         Version: '2012-10-17'
         Statement:


### PR DESCRIPTION
Fill in missing substitution variable so the rolename is correct. The rolename previously would not have been filled out correctly, which may have lead to confusion when reading the IAM policy.