### PR TITLE
Updated templates for AWS Account Tags feature

### DIFF
--- a/kubecost-masterpayer-account-permissions.yaml
+++ b/kubecost-masterpayer-account-permissions.yaml
@@ -71,3 +71,10 @@ Resources:
           - s3:List*
           Resource:
           - !Sub 'arn:aws:s3:::${AthenaCURBucket}*'
+        - Sid: ReadAccessToAccountTags
+          Effect: Allow
+          Action:
+          - organizations:ListAccounts
+          - organizations:ListTagsForResource
+          Resource: 
+          - "*"

--- a/kubecost-single-account-permissions.yaml
+++ b/kubecost-single-account-permissions.yaml
@@ -104,3 +104,10 @@ Resources:
           - s3:List*
           Resource:
           - !Sub 'arn:aws:s3:::${AthenaCURBucket}*'
+        - Sid: ReadAccessToAccountTags
+          Effect: Allow
+          Action:
+          - organizations:ListAccounts
+          - organizations:ListTagsForResource
+          Resource: 
+          - "*"


### PR DESCRIPTION
Add read access to `organizations:ListAccounts` and `organizations:ListTagsForResource`