### PR TITLE
AthenaCURBucket description

### DIFF
--- a/kubecost-masterpayer-account-permissions.yaml
+++ b/kubecost-masterpayer-account-permissions.yaml
@@ -5,7 +5,7 @@ Description: Kubecost Masterpayer Account Template
 
 Parameters:
   AthenaCURBucket:
-    Description: The bucket that athena results are written to
+    Description: The bucket where the CUR is sent from the “Setting up the CUR” step.
     Type: String
   KubecostClusterID:
     Description: Amazon account running kubecost that requires access.

--- a/kubecost-single-account-permissions.yaml
+++ b/kubecost-single-account-permissions.yaml
@@ -5,7 +5,7 @@ Description: Kubecost Masterpayer Account Template
 
 Parameters:
   AthenaCURBucket:
-    Description: The bucket that athena results are written to
+    Description: The bucket where the CUR is sent from the “Setting up the CUR” step.
     Type: String
   SpotDataFeedBucketName:
     Description: Optional. The AWS account ID containing the cluster with kubecost.

--- a/kubecost-single-account-permissions.yaml
+++ b/kubecost-single-account-permissions.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: The bucket where the CUR is sent from the “Setting up the CUR” step.
     Type: String
   SpotDataFeedBucketName:
-    Description: Optional. The AWS account ID containing the cluster with kubecost.
+    Description: Optional. The bucket where the spot data feed is sent from the “Setting up the Spot Data feed” step.
     Type: String
 
 Conditions:

--- a/kubecost-sub-account-permissions.yaml
+++ b/kubecost-sub-account-permissions.yaml
@@ -8,7 +8,7 @@ Parameters:
     Description: Your AWS masterpayer account
     Type: String
   SpotDataFeedBucketName:
-    Description: The AWS account ID containing the cluster with kubecost.
+    Description: Optional. The bucket where the spot data feed is sent from the “Setting up the Spot Data feed” step.
     Type: String
 
 Conditions:


### PR DESCRIPTION
Updated the `AthenaCURBucket` description to match the documentation found here: https://guide.kubecost.com/hc/en-us/articles/4407595928087-AWS-Cloud-Integration#step-3-setting-up-iam-permissions

In response to issue #12 